### PR TITLE
add mint screen on native and web

### DIFF
--- a/app/mint.tsx
+++ b/app/mint.tsx
@@ -1,0 +1,10 @@
+import { H1 } from 'tamagui'
+import { PageContainer } from '~/code/ui/PageContainer'
+
+export default function MintPage() {
+  return (
+    <PageContainer>
+      <H1>Mint</H1>
+    </PageContainer>
+  )
+}

--- a/code/home/HomeIcons.tsx
+++ b/code/home/HomeIcons.tsx
@@ -1,7 +1,8 @@
-import { Bell, Home, User } from '@tamagui/lucide-icons'
+import { Bell, Home, User, Bitcoin } from '@tamagui/lucide-icons'
 
 export const HomeIcons = {
   Home,
   Notifications: Bell,
   User: User,
+  Mint: Bitcoin,
 }

--- a/code/home/HomeLayout.native.tsx
+++ b/code/home/HomeLayout.native.tsx
@@ -14,6 +14,19 @@ export function HomeLayout() {
       }}
     >
       <Tabs.Screen
+        name="mint"
+        options={{
+          title: 'Mint',
+          tabBarIcon: ({ color }) => (
+            <HomeIcons.Mint
+              size={20}
+              color={color}
+            />
+          ),
+        }}
+      />
+
+      <Tabs.Screen
         name="(feed)"
         options={{
           title: 'Feed',

--- a/code/home/HomeLayout.tsx
+++ b/code/home/HomeLayout.tsx
@@ -112,6 +112,12 @@ function NavLinks() {
   return (
     <>
       <SideMenuLink
+        href="/mint"
+        Icon={HomeIcons.Mint}
+      >
+        Mint
+      </SideMenuLink>
+      <SideMenuLink
         href="/"
         subPaths={['/post/']}
         Icon={HomeIcons.Home}

--- a/routes.d.ts
+++ b/routes.d.ts
@@ -2,18 +2,9 @@ import type { OneRouter } from 'one'
 
 declare module 'one' {
   export namespace OneRouter {
-    export interface __routes<T extends string = string>
-      extends Record<string, unknown> {
-      StaticRoutes:
-        | `/`
-        | `/(feed)`
-        | `/(feed)/`
-        | `/_sitemap`
-        | `/notifications`
-        | `/profile`
-      DynamicRoutes:
-        | `/(feed)/post/${OneRouter.SingleRoutePart<T>}`
-        | `/post/${OneRouter.SingleRoutePart<T>}`
+    export interface __routes<T extends string = string> extends Record<string, unknown> {
+      StaticRoutes: `/` | `/(feed)` | `/(feed)/` | `/_sitemap` | `/mint` | `/notifications` | `/profile`
+      DynamicRoutes: `/(feed)/post/${OneRouter.SingleRoutePart<T>}` | `/post/${OneRouter.SingleRoutePart<T>}`
       DynamicRouteTemplate: `/(feed)/post/[id]` | `/post/[id]`
       IsTyped: true
     }


### PR DESCRIPTION
(tried copilot ai here)

This pull request introduces a new "Mint" feature to the application, including updates to the UI components and navigation structure. The most important changes are the addition of a `MintPage` component, updates to the `HomeIcons` to include a new icon, and modifications to the `HomeLayout` to integrate the new "Mint" screen.

### New Feature: Mint Page

* [`app/mint.tsx`](diffhunk://#diff-f9ce35364fe94f1e0f6de21d690d49adf189506ac941571c69585ae49228458aR1-R10): Added a new `MintPage` component that uses `PageContainer` and `H1` from `tamagui` to display the Mint page.

### UI Updates

* [`code/home/HomeIcons.tsx`](diffhunk://#diff-f64aee75eb66aac83888b8416dc35ff502ba3f913aeed6219a139ebe84d32dffL1-R7): Updated the `HomeIcons` object to include a new `Bitcoin` icon for the Mint feature.

### Navigation Updates

* [`code/home/HomeLayout.native.tsx`](diffhunk://#diff-94801b6a25947e8895732bb71f7b0389c05e38a54a2d02273ae7d84ebe74309eR16-R28): Added a new `Tabs.Screen` for the Mint page in the `HomeLayout` component, including the title and icon.
* [`code/home/HomeLayout.tsx`](diffhunk://#diff-0a76e45177e9811b90e1de1bae9e477483e1eb37dc82d3af703b1c76c6dc59faR114-R119): Added a new `SideMenuLink` for the Mint page in the `HomeLayoutMouse` function to update the side menu navigation.add blank mint screen for both native and web
<img width="1781" alt="image" src="https://github.com/user-attachments/assets/39d7fc11-736c-47ac-8fae-81403f381889">
